### PR TITLE
fix: empty array original driver incompatibility

### DIFF
--- a/src/bson.cpp
+++ b/src/bson.cpp
@@ -11,7 +11,7 @@ static Array HHVM_FUNCTION(bson_decode, const String& bson) {
   const bson_t * bsonObj;
   bool reached_eof;
 
-  Array output = Array();
+  Array output = Array::Create();
 
   reader = bson_reader_new_from_data((uint8_t *)bson.c_str(), bson.size());
   bsonObj = bson_reader_read(reader, &reached_eof);
@@ -28,11 +28,11 @@ static Array HHVM_FUNCTION(bson_decode_multiple, const String& bson) {
   bool reached_eof;
 
   int i = 0;
-  Array output = Array();
+  Array output = Array::Create();
 
   reader = bson_reader_new_from_data((uint8_t *)bson.c_str(), bson.size());
   while ((bsonObj = bson_reader_read(reader, &reached_eof))) {
-    Array document = Array();
+    Array document = Array::Create();
     bsonToVariant(bsonObj, &document);
     output.add(i++, document);
   }

--- a/src/decode.cpp
+++ b/src/decode.cpp
@@ -80,7 +80,7 @@ void bsonToArray(bson_iter_t* iter, Array* output, bool isDocument) {
 
   bson_init_static(&bson, document, document_len);
 
-  Array child = Array();
+  Array child = Array::Create();
   bsonToVariant(&bson, &child);
 
   output->add(
@@ -221,7 +221,7 @@ void bsonToMongoCodeWithScope(bson_iter_t* iter, Array* output) {
   bson_t bson;
   bson_init_static(&bson, scope, scope_len);
 
-  Array scopeArray = Array();
+  Array scopeArray = Array::Create();
   bsonToVariant(&bson, &scopeArray);
 
   bsonToObject(iter, output,
@@ -244,11 +244,11 @@ void bsonToMongoBinData(bson_iter_t* iter, Array* output) {
 }
 
 void bsonToMongoMaxKey(bson_iter_t* iter, Array* output) {
-  bsonToObject(iter, output, &s_MongoMaxKey, Array());
+  bsonToObject(iter, output, &s_MongoMaxKey, Array::Create());
 }
 
 void bsonToMongoMinKey(bson_iter_t* iter, Array* output) {
-  bsonToObject(iter, output, &s_MongoMinKey, Array());
+  bsonToObject(iter, output, &s_MongoMinKey, Array::Create());
 
 }
 }


### PR DESCRIPTION
When getting empty array from mongo, array converts to null in php.
