### PR TITLE
Issue#19 Ubuntu 14.04.1 make failing

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -83,7 +83,7 @@ void stringToBSON(const String& value, const char* key, bson_t* bson) {
 
 
 void objectToBSON(const Object& value, const char* key, bson_t* bson) {
-  const String& className = value->getClassName();
+  const String& className = value->o_getClassName();
 
   if (className == s_MongoId) {
     mongoIdToBSON(value, key, bson);


### PR DESCRIPTION
### make error
[ 33%] Building CXX object CMakeFiles/mongo.dir/src/encode.cpp.o
/usr/src/mongofill-hhvm/src/encode.cpp: In function ‘void HPHP::objectToBSON(const HPHP::Object&, const char*, bson_t*)’:
/usr/src/mongofill-hhvm/src/encode.cpp:86:36: error: ‘class HPHP::ObjectData’ has no member named ‘getClassName’
   const String& className = value->getClassName();
                                    ^
make[2]: *** [CMakeFiles/mongo.dir/src/encode.cpp.o] Error 1
make[1]: *** [CMakeFiles/mongo.dir/all] Error 2
make: *** [all] Error 2

### hhvm --version
HipHop VM 3.4.2 (rel)
Compiler: tags/HHVM-3.4.2-0-g40d85d7386b3342ab848fc45c6892433c89ef5b2
Repo schema: 13cba877c4300d1d0481b3f40eb128a5115d4e08
Extension API: 20140829