### PR TITLE
HHVM 3.12.0 compatibility

### DIFF
--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -29,7 +29,7 @@ void variantToBSON(const Variant& value, const char* key, bson_t* bson) {
     case KindOfDouble:
       doubleToBSON(value.toDouble(), key, bson);
       break;
-    case KindOfStaticString:
+    case KindOfPersistentString:
     case KindOfString:
       stringToBSON(value.toString(), key, bson);
       break;


### PR DESCRIPTION
Use KindOfPersistentString instead of KindOfStaticString, per change in hhvm:

https://github.com/facebook/hhvm/commit/127a039edfed7558bb3524cf02a42a0da0a3f7fc